### PR TITLE
feat(geodata): ajouter la fiche ogr2ogr

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -40,10 +40,10 @@ Ce depot contient la source du site https://mborne.github.io, genere avec MkDocs
 
 ## Regle creation fiche outil/service
 
-- Le chemin de la fiche doit etre `docs/outils/{nom}/index.md`.
-- Les metadonnees YAML doivent etre renseignées (tags)
-- Les tags existants peuvent etre recuperes depuis `docs/index.md`.
-- La mention "> 🤖 Rédaction assistée par IA." doit être présente dans les fiches générées par IA.
+- Pour une nouvelle fiche, privilégier `docs/outils/{nom}/index.md` (certaines fiches existantes utilisent encore `README.md`).
+- Les metadonnees YAML doivent etre renseignees (tags).
+- Les tags existants peuvent etre recuperes depuis `docs/outils/index.md`.
+- La mention "> 🤖 Rédaction assistée par IA." doit etre presente dans les fiches generees par IA.
 
 ## References
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -38,6 +38,13 @@ Ce depot contient la source du site https://mborne.github.io, genere avec MkDocs
 - Plusieurs dossiers d'exemples sont exclus du build via le plugin `exclude` dans `mkdocs.yml`.
 - `mkdocs.yml` utilise des tags YAML specifiques (voir `.vscode/settings.json`) ; eviter les reformattages agressifs de ce fichier.
 
+## Regle creation fiche outil/service
+
+- Le chemin de la fiche doit etre `docs/outils/{nom}/index.md`.
+- Les metadonnees YAML doivent etre renseignées (tags)
+- Les tags existants peuvent etre recuperes depuis `docs/index.md`.
+- La mention "> 🤖 Rédaction assistée par IA." doit être présente dans les fiches générées par IA.
+
 ## References
 
 - Guide projet : [README.md](README.md)

--- a/docs/geodata/index.md
+++ b/docs/geodata/index.md
@@ -11,9 +11,12 @@
 
 ## Les utilitaires
 
+* [ogr2ogr](../outils/ogr2ogr/index.md) - Conversion, transformation et chargement de donnees vectorielles.
+
 !!!info "En construction"
 
-    Voir [issue 9](https://github.com/mborne/mborne.github.io/issues/9) - ogr2ogr, mapshaper,...
+    Voir [issue 9](https://github.com/mborne/mborne.github.io/issues/9) pour mapshaper, osm2pgsql et grass.
+
 
 ## Les services
 

--- a/docs/geodata/index.md
+++ b/docs/geodata/index.md
@@ -11,7 +11,7 @@
 
 ## Les utilitaires
 
-* [ogr2ogr](../outils/ogr2ogr/index.md) - Conversion, transformation et chargement de donnees vectorielles.
+* [ogr2ogr](../outils/ogr2ogr/index.md) - Conversion, transformation et chargement de données vectorielles.
 
 !!!info "En construction"
 

--- a/docs/outils/ogr2ogr/index.md
+++ b/docs/outils/ogr2ogr/index.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - Outil
+  - Fichiers
+  - Base de données
+search:
+  boost: 2
+---
+
+# ogr2ogr
+
+`ogr2ogr` est l'outil de conversion et de transformation vectorielle de GDAL.
+
+## Cas d'utilisation
+
+* convertir entre formats (GeoJSON, Shapefile, GPKG, PostGIS, ...),
+* reprojeter les géométries,
+* filtrer les colonnes ou les entités,
+* préparer des données pour un chargement en base.
+
+## Installation
+
+Le binaire `ogr2ogr` est fourni avec GDAL.
+
+Selon l'environnement :
+
+* Linux: paquet `gdal-bin` (Debian/Ubuntu),
+* [Conda](../conda/README.md): paquet `gdal`,
+* Windows : binaire installé avec [QGIS](../qgis/README.md)
+
+Vérifier l'installation :
+
+```bash
+ogr2ogr --version
+```
+
+## Exemples
+
+### Convertir un fichier Shapefile en GeoJSON
+
+```bash
+ogr2ogr -f GeoJSON zones.geojson zones.shp
+```
+
+### Reprojeter en WGS84 (EPSG:4326)
+
+```bash
+ogr2ogr -f GPKG zones-4326.gpkg zones.gpkg -t_srs EPSG:4326
+```
+
+### Filtrer les attributs exportés
+
+```bash
+ogr2ogr -f GeoJSON communes.geojson communes.gpkg communes -select "insee,nom,population"
+```
+
+### Charger des données dans PostGIS
+
+```bash
+ogr2ogr \
+  -f PostgreSQL \
+  "PG:host=localhost dbname=gis user=gis password=gis" \
+  communes.gpkg \
+  communes \
+  -nln public.communes \
+  -overwrite
+```
+
+## Ressources
+
+Documentation officielle :
+
+* [gdal.org - ogr2ogr](https://gdal.org/programs/ogr2ogr.html)
+* [gdal.org - Vector drivers](https://gdal.org/drivers/vector/index.html)

--- a/docs/outils/ogr2ogr/index.md
+++ b/docs/outils/ogr2ogr/index.md
@@ -1,10 +1,10 @@
 ---
 tags:
-  - Outil
-  - Fichiers
-  - Base de données
+    - Outil
+    - Fichiers
+    - Base de données
 search:
-  boost: 2
+    boost: 2
 ---
 
 # ogr2ogr


### PR DESCRIPTION
## Résumé
- création de la fiche `ogr2ogr` au bon emplacement: `docs/outils/ogr2ogr/index.md`
- ajout des métadonnées YAML (tags + boost de recherche)
- mise à jour de la section utilitaires dans `docs/geodata/index.md` pour pointer vers la fiche
- ajout de la règle de création de fiche dans `AGENT.md`

## Issue liée
Refs #9

## Vérification
- navigation/lien depuis `docs/geodata/index.md`
- front matter YAML valide sur la fiche `ogr2ogr`
