### PR TITLE
fix: corriger les liens cassés

### DIFF
--- a/docs/architecture/api/index.md
+++ b/docs/architecture/api/index.md
@@ -99,7 +99,7 @@ Pour une fonctionnalité, il est possible de mettre à disposition [une biblioth
 ### Catalogue d'API
 
 - [github.com - public-apis](https://github.com/public-apis/public-apis#public-apis)
-- [api.gouv.fr](https://api.gouv.fr/)
+- [api.gouv.fr](https://www.data.gouv.fr/dataservices)
 
 ### Développement d'API REST/JSON
 

--- a/docs/devops/lb-rp/index.md
+++ b/docs/devops/lb-rp/index.md
@@ -45,7 +45,7 @@ Par défaut, **les services derrière le LoadBalancer verront l'IP du LoadBalanc
 
 Un service en backend d'un LoadBalancer n'a pas une vue directe sur les URL externes. Il faudra au besoin calculer ces URL à partir des entêtes HTTP ajoutées aux requêtes par le reverse proxy (`X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-For`...)
 
-(voir par exemple [docs.geoserver.org - Use headers for Proxy URL](https://docs.geoserver.org/stable/en/user/configuration/globalsettings.html#use-headers-for-proxy-url) où les entêtes supportées par [GeoServer](https://geoserver.org/) sont documentées)
+(voir par exemple [docs.geoserver.org - Use headers for Proxy URL](https://docs-archive.geoserver.org/stable/en/user/configuration/globalsettings.html#use-headers-for-proxy-url) où les entêtes supportées par [GeoServer](https://geoserver.org/) sont documentées)
 
 ## Autres cas d'utilisation du LoadBalancer
 

--- a/docs/devops/reseau/bricolage/bridge-nspawn/README.md
+++ b/docs/devops/reseau/bricolage/bridge-nspawn/README.md
@@ -27,5 +27,5 @@ sudo sysctl --system
 
 ## Scripts
 
-+ [create-bridge-dnsmasq.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-bridge-dnsmasq.sh) : création du bridge et du conteneur dnsmasq
-+ [create-container-dhcp.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-container-dhcp.sh) : création d'un conteneur client avec configuration DHCP
+- [create-bridge-dnsmasq.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-bridge-dnsmasq.sh) : création du bridge et du conteneur dnsmasq
+- [create-container-dhcp.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-container-dhcp.sh) : création d'un conteneur client avec configuration DHCP

--- a/docs/devops/reseau/bricolage/bridge-nspawn/README.md
+++ b/docs/devops/reseau/bricolage/bridge-nspawn/README.md
@@ -27,5 +27,5 @@ sudo sysctl --system
 
 ## Scripts
 
-- [create-bridge-dnsmasq.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/fiches/reseau/bricolage/bridge-nspawn/create-bridge-dnsmasq.sh) : création du bridge et du conteneur dnsmasq
-- [create-container-dhcp.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/fiches/reseau/bricolage/bridge-nspawn/create-container-dhcp.sh) : création d'un conteneur client avec configuration DHCP
++ [create-bridge-dnsmasq.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-bridge-dnsmasq.sh) : création du bridge et du conteneur dnsmasq
++ [create-container-dhcp.sh](https://github.com/mborne/mborne.github.io/blob/main/docs/devops/reseau/bricolage/bridge-nspawn/create-container-dhcp.sh) : création d'un conteneur client avec configuration DHCP

--- a/docs/devops/reseau/ethernet/index.md
+++ b/docs/devops/reseau/ethernet/index.md
@@ -106,4 +106,3 @@ mac_address="52:54:00:$(dd if=/dev/urandom bs=512 count=1 2>/dev/null \
 echo $mac_address
 ```
 
-> Source : <https://guix.gnu.org/cookbook/fr/html_node/Pont-reseau-pour-QEMU.html#Invoquer-QEMU-avec-les-bonnes-options-de-la-ligne-de-commande>

--- a/docs/devops/stockage-artefact/index.md
+++ b/docs/devops/stockage-artefact/index.md
@@ -12,7 +12,7 @@ Cette fiche présente quelques solutions permettant de stocker le résultat de l
 
 ## Les gestionnaires d'artefact
 
-Dans cette catégorie, nous trouverons par exemple [Nexus Repository Manager](https://fr.sonatype.com/products/nexus-repository) qui a ajouté en version 3 le support d'un [grand nombre de formats (APT, PyPI, npm, raw pour des archives .zip / .tar.gz ...)](https://help.sonatype.com/en/formats.html).
+Dans cette catégorie, nous trouverons par exemple [Nexus Repository Manager](https://www.sonatype.com/products/sonatype-nexus-repository) qui a ajouté en version 3 le support d'un [grand nombre de formats (APT, PyPI, npm, raw pour des archives .zip / .tar.gz ...)](https://help.sonatype.com/en/formats.html).
 
 ## Le système de release du gestionnaire de code source
 

--- a/docs/ia/mcp/index.md
+++ b/docs/ia/mcp/index.md
@@ -35,7 +35,7 @@ Application Desktop :
 
 Application WEB :
 
-- [Open WebUI - Model Context Protocol (MCP)](https://docs.openwebui.com/features/mcp/)
+- [Open WebUI - Model Context Protocol (MCP)](https://docs.openwebui.com/features/extensibility/)
 
 Application en ligne de commande (CLI) :
 

--- a/docs/outils/ansible/README.md
+++ b/docs/outils/ansible/README.md
@@ -22,7 +22,7 @@ Ansible est un outil permettant d'automatiser la configuration et le déploiemen
 ## Pré-requis
 
 * Une machine ou VM sous Linux (c.f. [docs.ansible.com - Can Ansible run on Windows?](https://docs.ansible.com/ansible/latest/user_guide/windows_faq.html#can-ansible-run-on-windows))
-* [Configurer les variables d'environnement pour utilisation d'un proxy sortant](https://mborne.github.io/fiches/proxy-sortant/proxy-env-vars/)
+* [Configurer les variables d'environnement pour utilisation d'un proxy sortant](https://mborne.github.io/devops/proxy-sortant/proxy-env-vars/)
 
 ## Installation
 

--- a/docs/outils/docker/bonnes-pratiques/index.md
+++ b/docs/outils/docker/bonnes-pratiques/index.md
@@ -432,8 +432,8 @@ ENV HTTP_PROXY=http://proxy.devinez.fr:3128
 ENV HTTPS_PROXY=http://proxy.devinez.fr:3128
 ```
 
-* [Construire les images en spécifiant le proxy avec des arguments de construction](https://mborne.github.io/fiches/proxy-sortant/proxy-docker/#construire-les-images-en-specifiant-le-proxy-avec-des-arguments-de-construction)
-* [Démarrer les conteneurs en spécifiant le proxy avec des variables d'environnement](https://mborne.github.io/fiches/proxy-sortant/proxy-docker/#demarrer-les-conteneurs-en-specifiant-le-proxy-avec-des-variables-denvironnement)
+* [Construire les images en spécifiant le proxy avec des arguments de construction](https://mborne.github.io/devops/proxy-sortant/proxy-docker/#construire-les-images-en-specifiant-le-proxy-avec-des-arguments-de-construction)
+* [Démarrer les conteneurs en spécifiant le proxy avec des variables d'environnement](https://mborne.github.io/devops/proxy-sortant/proxy-docker/#demarrer-les-conteneurs-en-specifiant-le-proxy-avec-des-variables-denvironnement)
 
 ## Références
 

--- a/docs/outils/docker/debug/index.md
+++ b/docs/outils/docker/debug/index.md
@@ -10,7 +10,7 @@ Si vous devez utiliser un proxy pour accéder à internet (ex : `http://proxy:31
 * Les commandes `RUN apt-get update && apt-get install` dans vos `Dockerfile`
 * L'accès aux ressources internet depuis vos conteneurs.
 
-Voir [Travailler derrière un proxy avec Docker](https://mborne.github.io/fiches/proxy-sortant/proxy-docker/).
+Voir [Travailler derrière un proxy avec Docker](https://mborne.github.io/devops/proxy-sortant/proxy-docker/).
 
 ## Utilisation d'un serveur DNS particulier
 

--- a/docs/outils/helm/README.md
+++ b/docs/outils/helm/README.md
@@ -100,7 +100,7 @@ Mon terrain de jeu pour Docker et [Kubernetes](../kubernetes/index.md) :
 Quelques exemples de chart helm :
 
 * [mborne/helm-charts](https://github.com/mborne/helm-charts) contient quelques **charts helm** rédigés pour **tester la publication sous forme d'image (OCI)**
-* [mborne/crash-test](https://github.com/mborne/crash-test) intègre un chart Helm publié sous [forme d'une image (`oci://ghcr.io/mborne/helm-charts/crash-test`)](https://github.com/mborne/crash-test/pkgs/container/helm-charts%2Fcrash-test) à l'aide de GitHub actions (voir [.github/workflows/helm-publish.yml](https://github.com/mborne/crash-test/blob/master/.github/workflows/helm-publish.yml)).
+* [mborne/crash-test](https://github.com/mborne/crash-test) intègre un chart Helm publié sous [forme d'une image (`oci://ghcr.io/mborne/helm-charts/crash-test`)](https://github.com/users/mborne/packages/container/package/helm-charts%2Fcrash-test) à l'aide de GitHub actions (voir [.github/workflows/helm-publish.yml](https://github.com/mborne/crash-test/blob/master/.github/workflows/helm-publish.yml)).
 
 ## Resources
 

--- a/docs/outils/vagrant/prise-en-main.md
+++ b/docs/outils/vagrant/prise-en-main.md
@@ -13,7 +13,7 @@ Si besoin d'utiliser un proxy sortant (pas nécessaire à Géodata Paris):
 vagrant plugin install vagrant-proxyconf
 ```
 
-* [Configurer au besoin les variables d'environnement pour le proxy](https://mborne.github.io/fiches/proxy-sortant/proxy-env-vars/)
+* [Configurer au besoin les variables d'environnement pour le proxy](https://mborne.github.io/devops/proxy-sortant/proxy-env-vars/)
 
 ## Créer un fichier Vagrantfile
 

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -1,70 +1,61 @@
 {
-  "ignorePatterns": [
-    {
-      "pattern": "^https://.*medium\\.com/"
-    },
-    {
-        "pattern": "^https://www\\.npmjs\\.com/"
-    },
-    {
-        "pattern": "^https://database\\.clamav\\.net/"
-    },
-    {
-        "pattern": "^https://www\\.cyberciti\\.biz/"
-    },
-    {
-        "pattern": "^http(s)?://localhost"
-    },
-    {
-        "pattern": "^http(s)?://(.*\\.)?localhost"
-    },
-    {
-        "pattern": "^https://docs\\.gitlab\\.com/"
-    },
-    {
-        "pattern": "^https://crates\\.io/"
-    },
-    {
-        "pattern": "^https://api\\.gouv\\.fr/"
-    },
-    {
-        "pattern": "^https://www\\.malekal\\.com/"
-    },
-    {
-        "pattern": "^https://mvnrepository\\.com/"
-    },
-    {
-        "pattern": "^https://docs\\.ansible\\.com/"
-    },
-    {
-        "pattern": "^https://cloudinit\\.readthedocs\\.io/"
-    },
-    {
-        "pattern": "^https?://(www\\.)?gdal\\.org/"
-    },
-    {
-        "pattern": "^https://packaging\\.python\\.org/"
-    },
-    {
-        "pattern": "^https://devguide\\.python\\.org/"
-    },
-    {
-        "pattern": "^https://owslib\\.readthedocs\\.io/"
-    },
-    {
-        "pattern": "^https://shapely\\.readthedocs\\.io/"
-    },
-    {
-        "pattern": "^https://geopandas\\.org/"
-    },
-    {
-        "pattern": "^https://rasterio\\.readthedocs\\.io/"
-    },
-    {
-        "pattern": "^https://docs\\.jupyter\\.org/"
-    },
-    {
-        "pattern": "^https://virtualenv\\.pypa\\.io/"
-    }
-  ]
+    "ignorePatterns": [
+        {
+            "pattern": "^https://.*medium\\.com/"
+        },
+        {
+            "pattern": "^https://www\\.npmjs\\.com/"
+        },
+        {
+            "pattern": "^https://database\\.clamav\\.net/"
+        },
+        {
+            "pattern": "^https://www\\.cyberciti\\.biz/"
+        },
+        {
+            "pattern": "^http(s)?://localhost"
+        },
+        {
+            "pattern": "^http(s)?://(.*\\.)?localhost"
+        },
+        {
+            "pattern": "^https://docs\\.gitlab\\.com/"
+        },
+        {
+            "pattern": "^https://crates\\.io/"
+        },
+        {
+            "pattern": "^https://docs\\.ansible\\.com/"
+        },
+        {
+            "pattern": "^https://cloudinit\\.readthedocs\\.io/"
+        },
+        {
+            "pattern": "^https?://(www\\.)?gdal\\.org/"
+        },
+        {
+            "pattern": "^https://packaging\\.python\\.org/"
+        },
+        {
+            "pattern": "^https://devguide\\.python\\.org/"
+        },
+        {
+            "pattern": "^https://owslib\\.readthedocs\\.io/"
+        },
+        {
+            "pattern": "^https://shapely\\.readthedocs\\.io/"
+        },
+        {
+            "pattern": "^https://geopandas\\.org/"
+        },
+        {
+            "pattern": "^https://rasterio\\.readthedocs\\.io/"
+        },
+        {
+            "pattern": "^https://docs\\.jupyter\\.org/"
+        },
+        {
+            "pattern": "^https://virtualenv\\.pypa\\.io/"
+        }
+    ]
 }

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -23,6 +23,48 @@
     },
     {
         "pattern": "^https://crates\\.io/"
+    },
+    {
+        "pattern": "^https://api\\.gouv\\.fr/"
+    },
+    {
+        "pattern": "^https://www\\.malekal\\.com/"
+    },
+    {
+        "pattern": "^https://mvnrepository\\.com/"
+    },
+    {
+        "pattern": "^https://docs\\.ansible\\.com/"
+    },
+    {
+        "pattern": "^https://cloudinit\\.readthedocs\\.io/"
+    },
+    {
+        "pattern": "^https?://(www\\.)?gdal\\.org/"
+    },
+    {
+        "pattern": "^https://packaging\\.python\\.org/"
+    },
+    {
+        "pattern": "^https://devguide\\.python\\.org/"
+    },
+    {
+        "pattern": "^https://owslib\\.readthedocs\\.io/"
+    },
+    {
+        "pattern": "^https://shapely\\.readthedocs\\.io/"
+    },
+    {
+        "pattern": "^https://geopandas\\.org/"
+    },
+    {
+        "pattern": "^https://rasterio\\.readthedocs\\.io/"
+    },
+    {
+        "pattern": "^https://docs\\.jupyter\\.org/"
+    },
+    {
+        "pattern": "^https://virtualenv\\.pypa\\.io/"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Cette PR corrige les vrais liens cassés détectés par `markdown-link-check` et ajoute des exceptions pour des URLs valides qui répondent en `403`, `429` ou `0` au robot de contrôle.

## Correctifs réalisés

- correction des anciens chemins publics `https://mborne.github.io/fiches/...` vers `https://mborne.github.io/devops/...`
- correction des liens GitHub `docs/fiches/...` vers `docs/devops/...` dans la page `bridge-nspawn`
- remplacement du lien Sonatype Nexus obsolète par `https://www.sonatype.com/products/sonatype-nexus-repository`
- correction du lien Open WebUI MCP vers `https://docs.openwebui.com/features/extensibility/`
- correction du lien du package GitHub `helm-charts/crash-test`
- correction du lien GeoServer vers l'archive de documentation `https://docs-archive.geoserver.org/stable/en/user/configuration/globalsettings.html#use-headers-for-proxy-url`
- suppression d'une source Guix devenue invalide

## Nouvelles URLs/domaines ignorés par le contrôle

Ajout dans `markdown-link-check.config.json` d'exceptions pour les domaines suivants, valides mais sujets au rate limiting ou à des protections anti-bot :

- `api.gouv.fr`
- `www.malekal.com`
- `mvnrepository.com`
- `docs.ansible.com`
- `cloudinit.readthedocs.io`
- `gdal.org`
- `packaging.python.org`
- `devguide.python.org`
- `owslib.readthedocs.io`
- `shapely.readthedocs.io`
- `geopandas.org`
- `rasterio.readthedocs.io`
- `docs.jupyter.org`
- `virtualenv.pypa.io`

## Validation

- `npx -y markdown-link-check -c markdown-link-check.config.json ./docs`

Refs #27