### PR TITLE
docs(mcp): ajouter une fiche workflow GitHub issue -> branche -> PR -> revue

### DIFF
--- a/docs/ia/mcp/index.md
+++ b/docs/ia/mcp/index.md
@@ -45,6 +45,10 @@ Bibliothèques :
 
 - [langchain-mcp-adapters](https://docs.langchain.com/oss/python/langchain/mcp#model-context-protocol-mcp)
 
+## Cas pratique
+
+- [MCP GitHub - de l'issue à la revue de code](mcp-github.md)
+
 ## Quelques frameworks
 
 Pour développer son propre MCP :

--- a/docs/ia/mcp/mcp-github.md
+++ b/docs/ia/mcp/mcp-github.md
@@ -1,0 +1,122 @@
+---
+tags:
+    - MCP
+    - GitHub
+    - Workflow
+---
+
+# MCP GitHub - De l'issue a la revue de code
+
+Cette fiche presente un workflow de bout en bout avec MCP GitHub:
+
+1. creer une issue,
+2. traiter l'issue sur une branche,
+3. creer une pull request,
+4. faire la revue de code.
+
+## Prerequis
+
+- Avoir un serveur MCP GitHub configure et accessible par votre client (VS Code, agent CLI, etc.).
+- Avoir les permissions sur le depot cible (lecture/ecriture, creation de branche et de PR).
+
+## 1) Generation d'issue
+
+Objectif: decrire clairement le besoin, le contexte et les criteres d'acceptation.
+
+Exemple avec l'outil `mcp_github-mcp_issue_write`:
+
+```json
+{
+  "method": "create",
+  "owner": "mborne",
+  "repo": "mborne.github.io",
+  "title": "Ajouter une fiche MCP GitHub",
+  "body": "## Objectif\nDocumenter issue -> branche -> PR -> revue.\n\n## Criteres d'acceptation\n- [ ] La page existe\n- [ ] Un exemple est donne pour chaque etape"
+}
+```
+
+Bonnes pratiques:
+
+- Rediger un titre actionnable (verbe a l'infinitif).
+- Ajouter des criteres d'acceptation verificables.
+- Ajouter labels/assignees si le projet les utilise.
+
+## 2) Traitement d'une issue sur une branche
+
+Objectif: isoler le travail et faciliter la revue.
+
+Convention de nommage recommandee:
+
+- `feat/<numero-issue>-<description-courte>`
+
+Exemple:
+
+```bash
+git checkout -b feat/29-mcp-github-workflow
+```
+
+Puis:
+
+- implementer les changements,
+- verifier localement,
+- commit avec un message clair.
+
+Exemple de commit:
+
+```bash
+git add docs/ia/mcp/mcp-github.md docs/ia/mcp/index.md
+git commit -m "docs(mcp): ajouter fiche workflow GitHub issue->PR"
+```
+
+## 3) Creation d'une Pull Request
+
+Objectif: proposer les changements de la branche vers la branche principale.
+
+Exemple avec `mcp_github-mcp_create_pull_request`:
+
+```json
+{
+  "owner": "mborne",
+  "repo": "mborne.github.io",
+  "base": "main",
+  "head": "feat/29-mcp-github-workflow",
+  "title": "docs(mcp): ajouter une fiche MCP GitHub",
+  "body": "Closes #29\n\nAjout d'une fiche de workflow: issue -> branche -> PR -> revue de code."
+}
+```
+
+Bonnes pratiques:
+
+- Referencer l'issue dans la description (`Closes #<id>`).
+- Ajouter une checklist de verification (liens, rendu, coherence).
+- Demander explicitement des reviewers.
+
+## 4) Revue de code
+
+Objectif: valider la qualite fonctionnelle et editoriale avant merge.
+
+Actions possibles via MCP GitHub:
+
+- commenter une PR,
+- demander des changements (`REQUEST_CHANGES`),
+- approuver (`APPROVE`).
+
+Exemple avec `mcp_github-mcp_pull_request_review_write`:
+
+```json
+{
+  "method": "create",
+  "owner": "mborne",
+  "repo": "mborne.github.io",
+  "pullNumber": 123,
+  "event": "COMMENT",
+  "body": "Merci. Le contenu est clair. Pouvez-vous ajouter un exemple de labels dans la creation d'issue ?"
+}
+```
+
+## Checklist rapide
+
+- [ ] L'issue decrit bien le besoin et les criteres d'acceptation.
+- [ ] La branche est dediee a une seule issue.
+- [ ] La PR reference l'issue et explique les changements.
+- [ ] La revue de code est tracee (commentaires, approbation, ou changements demandes).

--- a/docs/ia/mcp/mcp-github.md
+++ b/docs/ia/mcp/mcp-github.md
@@ -125,11 +125,20 @@ Exemple avec `mcp_github-mcp_pull_request_review_write`:
 
 Voici les prompts utilises pour produire cette fiche, de l'issue a la PR.
 
+References GitHub correspondantes:
+
+- Issue #29: https://github.com/mborne/mborne.github.io/issues/29
+- Branche de travail: https://github.com/mborne/mborne.github.io/tree/feat/29-mcp-github-workflow
+- Pull Request #30: https://github.com/mborne/mborne.github.io/pull/30
+- Comparaison branche -> main: https://github.com/mborne/mborne.github.io/compare/main...feat/29-mcp-github-workflow
+
 ### Prompt 1 - Creer l'issue
 
 ```text
 creer une issue pour ajouter fiche docs/ia/mcp/mcp-github.md presentant son utilisation pour la generation d'issue, le traitement d'issue sur une branche, la creation d'une PR et la revue de code
 ```
+
+Resultat: issue creee https://github.com/mborne/mborne.github.io/issues/29
 
 ### Prompt 2 - Traiter l'issue sur une branche et ouvrir la PR
 
@@ -137,11 +146,18 @@ creer une issue pour ajouter fiche docs/ia/mcp/mcp-github.md presentant son util
 traite l'issue sur une branche et fait une PR
 ```
 
+Resultat:
+
+- branche creee https://github.com/mborne/mborne.github.io/tree/feat/29-mcp-github-workflow
+- PR ouverte https://github.com/mborne/mborne.github.io/pull/30
+
 ### Prompt 3 - Ajouter des prompts en exemple dans la fiche
 
 ```text
 En exemple, donne les prompts correspondant a cette discussion (comment cette fiche est creee)
 ```
+
+Resultat: mise a jour de la PR existante https://github.com/mborne/mborne.github.io/pull/30
 
 ## Variante: prompt unique de bout en bout
 

--- a/docs/ia/mcp/mcp-github.md
+++ b/docs/ia/mcp/mcp-github.md
@@ -120,3 +120,33 @@ Exemple avec `mcp_github-mcp_pull_request_review_write`:
 - [ ] La branche est dediee a une seule issue.
 - [ ] La PR reference l'issue et explique les changements.
 - [ ] La revue de code est tracee (commentaires, approbation, ou changements demandes).
+
+## Prompts d'exemple (cette discussion)
+
+Voici les prompts utilises pour produire cette fiche, de l'issue a la PR.
+
+### Prompt 1 - Creer l'issue
+
+```text
+creer une issue pour ajouter fiche docs/ia/mcp/mcp-github.md presentant son utilisation pour la generation d'issue, le traitement d'issue sur une branche, la creation d'une PR et la revue de code
+```
+
+### Prompt 2 - Traiter l'issue sur une branche et ouvrir la PR
+
+```text
+traite l'issue sur une branche et fait une PR
+```
+
+### Prompt 3 - Ajouter des prompts en exemple dans la fiche
+
+```text
+En exemple, donne les prompts correspondant a cette discussion (comment cette fiche est creee)
+```
+
+## Variante: prompt unique de bout en bout
+
+Si vous voulez tout faire en une seule demande, vous pouvez utiliser:
+
+```text
+Traite l'issue #29: cree une branche feature, ajoute la fiche docs/ia/mcp/mcp-github.md (issue -> branche -> PR -> revue), mets a jour docs/ia/mcp/index.md avec un lien vers la fiche, commit, push et ouvre une PR avec "Closes #29".
+```

--- a/docs/ia/mcp/mcp-github.md
+++ b/docs/ia/mcp/mcp-github.md
@@ -5,23 +5,25 @@ tags:
     - Workflow
 ---
 
-# MCP GitHub - De l'issue a la revue de code
+# MCP GitHub - De l'issue à la revue de code
 
-Cette fiche presente un workflow de bout en bout avec MCP GitHub:
+Cette fiche présente un workflow de bout en bout avec MCP GitHub:
 
-1. creer une issue,
+1. créer une issue,
 2. traiter l'issue sur une branche,
 3. creer une pull request,
 4. faire la revue de code.
 
-## Prerequis
+## Prérequis
 
-- Avoir un serveur MCP GitHub configure et accessible par votre client (VS Code, agent CLI, etc.).
-- Avoir les permissions sur le depot cible (lecture/ecriture, creation de branche et de PR).
+- Avoir un serveur MCP GitHub configuré et accessible par votre client (VS Code, agent CLI, etc.).
+- Avoir les permissions sur le dépôt cible (lecture/écriture, création de branche et de PR).
 
-## 1) Generation d'issue
+## Principe
 
-Objectif: decrire clairement le besoin, le contexte et les criteres d'acceptation.
+### 1) Génération d'issue
+
+Objectif: décrire clairement le besoin, le contexte et les critères d'acceptation.
 
 Exemple avec l'outil `mcp_github-mcp_issue_write`:
 
@@ -31,21 +33,21 @@ Exemple avec l'outil `mcp_github-mcp_issue_write`:
   "owner": "mborne",
   "repo": "mborne.github.io",
   "title": "Ajouter une fiche MCP GitHub",
-  "body": "## Objectif\nDocumenter issue -> branche -> PR -> revue.\n\n## Criteres d'acceptation\n- [ ] La page existe\n- [ ] Un exemple est donne pour chaque etape"
+  "body": "## Objectif\nDocumenter issue -> branche -> PR -> revue.\n\n## Critères d'acceptation\n- [ ] La page existe\n- [ ] Un exemple est donné pour chaque étape"
 }
 ```
 
 Bonnes pratiques:
 
-- Rediger un titre actionnable (verbe a l'infinitif).
-- Ajouter des criteres d'acceptation verificables.
+- Rédiger un titre actionnable (verbe à l'infinitif).
+- Ajouter des critères d'acceptation vérifiables.
 - Ajouter labels/assignees si le projet les utilise.
 
-## 2) Traitement d'une issue sur une branche
+### 2) Traitement d'une issue sur une branche
 
 Objectif: isoler le travail et faciliter la revue.
 
-Convention de nommage recommandee:
+Convention de nommage recommandée:
 
 - `feat/<numero-issue>-<description-courte>`
 
@@ -57,8 +59,8 @@ git checkout -b feat/29-mcp-github-workflow
 
 Puis:
 
-- implementer les changements,
-- verifier localement,
+- implémenter les changements,
+- vérifier localement,
 - commit avec un message clair.
 
 Exemple de commit:
@@ -68,32 +70,19 @@ git add docs/ia/mcp/mcp-github.md docs/ia/mcp/index.md
 git commit -m "docs(mcp): ajouter fiche workflow GitHub issue->PR"
 ```
 
-## 3) Creation d'une Pull Request
+### 3) Création d'une Pull Request
 
 Objectif: proposer les changements de la branche vers la branche principale.
 
-Exemple avec `mcp_github-mcp_create_pull_request`:
-
-```json
-{
-  "owner": "mborne",
-  "repo": "mborne.github.io",
-  "base": "main",
-  "head": "feat/29-mcp-github-workflow",
-  "title": "docs(mcp): ajouter une fiche MCP GitHub",
-  "body": "Closes #29\n\nAjout d'une fiche de workflow: issue -> branche -> PR -> revue de code."
-}
-```
-
 Bonnes pratiques:
 
-- Referencer l'issue dans la description (`Closes #<id>`).
-- Ajouter une checklist de verification (liens, rendu, coherence).
+- Référencer l'issue dans la description (`Closes #<id>`).
+- Ajouter une checklist de vérification (liens, rendu, cohérence).
 - Demander explicitement des reviewers.
 
-## 4) Revue de code
+### 4) Revue de code
 
-Objectif: valider la qualite fonctionnelle et editoriale avant merge.
+Objectif: valider la qualité fonctionnelle et éditoriale avant merge.
 
 Actions possibles via MCP GitHub:
 
@@ -101,44 +90,32 @@ Actions possibles via MCP GitHub:
 - demander des changements (`REQUEST_CHANGES`),
 - approuver (`APPROVE`).
 
-Exemple avec `mcp_github-mcp_pull_request_review_write`:
-
-```json
-{
-  "method": "create",
-  "owner": "mborne",
-  "repo": "mborne.github.io",
-  "pullNumber": 123,
-  "event": "COMMENT",
-  "body": "Merci. Le contenu est clair. Pouvez-vous ajouter un exemple de labels dans la creation d'issue ?"
-}
-```
 
 ## Checklist rapide
 
-- [ ] L'issue decrit bien le besoin et les criteres d'acceptation.
-- [ ] La branche est dediee a une seule issue.
-- [ ] La PR reference l'issue et explique les changements.
-- [ ] La revue de code est tracee (commentaires, approbation, ou changements demandes).
+- [ ] L'issue décrit bien le besoin et les critères d'acceptation.
+- [ ] La branche est dédiée à une seule issue.
+- [ ] La PR référence l'issue et explique les changements.
+- [ ] La revue de code est tracée (commentaires, approbation, ou changements demandés).
 
-## Prompts d'exemple (cette discussion)
+## Prompts d'exemple
 
-Voici les prompts utilises pour produire cette fiche, de l'issue a la PR.
+Voici les prompts utilisés pour produire cette fiche, de l'issue à la PR.
 
-References GitHub correspondantes:
+Références GitHub correspondantes:
 
 - Issue #29: https://github.com/mborne/mborne.github.io/issues/29
 - Branche de travail: https://github.com/mborne/mborne.github.io/tree/feat/29-mcp-github-workflow
 - Pull Request #30: https://github.com/mborne/mborne.github.io/pull/30
 - Comparaison branche -> main: https://github.com/mborne/mborne.github.io/compare/main...feat/29-mcp-github-workflow
 
-### Prompt 1 - Creer l'issue
+### Prompt 1 - Créer l'issue
 
 ```text
-creer une issue pour ajouter fiche docs/ia/mcp/mcp-github.md presentant son utilisation pour la generation d'issue, le traitement d'issue sur une branche, la creation d'une PR et la revue de code
+créer une issue pour ajouter fiche docs/ia/mcp/mcp-github.md présentant son utilisation pour la génération d'issue, le traitement d'issue sur une branche, la création d'une PR et la revue de code
 ```
 
-Resultat: issue creee https://github.com/mborne/mborne.github.io/issues/29
+Résultat: issue créée https://github.com/mborne/mborne.github.io/issues/29
 
 ### Prompt 2 - Traiter l'issue sur une branche et ouvrir la PR
 
@@ -146,23 +123,23 @@ Resultat: issue creee https://github.com/mborne/mborne.github.io/issues/29
 traite l'issue sur une branche et fait une PR
 ```
 
-Resultat:
+Résultat:
 
-- branche creee https://github.com/mborne/mborne.github.io/tree/feat/29-mcp-github-workflow
+- branche créée https://github.com/mborne/mborne.github.io/tree/feat/29-mcp-github-workflow
 - PR ouverte https://github.com/mborne/mborne.github.io/pull/30
 
 ### Prompt 3 - Ajouter des prompts en exemple dans la fiche
 
 ```text
-En exemple, donne les prompts correspondant a cette discussion (comment cette fiche est creee)
+En exemple, donne les prompts correspondant à cette discussion (comment cette fiche est créée)
 ```
 
-Resultat: mise a jour de la PR existante https://github.com/mborne/mborne.github.io/pull/30
+Résultat: mise à jour de la PR existante https://github.com/mborne/mborne.github.io/pull/30
 
 ## Variante: prompt unique de bout en bout
 
 Si vous voulez tout faire en une seule demande, vous pouvez utiliser:
 
 ```text
-Traite l'issue #29: cree une branche feature, ajoute la fiche docs/ia/mcp/mcp-github.md (issue -> branche -> PR -> revue), mets a jour docs/ia/mcp/index.md avec un lien vers la fiche, commit, push et ouvre une PR avec "Closes #29".
+Traite l'issue #29: crée une branche feature, ajoute la fiche docs/ia/mcp/mcp-github.md (issue -> branche -> PR -> revue), mets à jour docs/ia/mcp/index.md avec un lien vers la fiche, commit, push et ouvre une PR avec "Closes #29".
 ```


### PR DESCRIPTION
Closes #29

## Résumé
- ajout de `docs/ia/mcp/mcp-github.md`
- documentation du workflow complet : génération d'issue, traitement sur branche, création de PR, revue de code
- ajout d'un lien depuis `docs/ia/mcp/index.md`

## Vérifications
- rendu Markdown vérifié
- cohérence des liens internes vérifiée